### PR TITLE
Rollback Android minSdk to 21 and clean up crosslens-core dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.2.2"
 android-compileSdk = "34"
-android-minSdk = "24"
+android-minSdk = "21"
 android-targetSdk = "34"
 androidx-activityCompose = "1.9.1"
 androidx-lifecycle = "2.8.0"
@@ -12,7 +12,6 @@ jetbrains-kotlinx-binary-compatibility = "0.16.3"
 kotlin = "2.0.20"
 spotless = "6.25.0"
 teogor-winds = "1.0.2"
-teogor-crosslens = "1.0.0-alpha01"
 vanniktech-maven = "0.29.0"
 ajalt-colormath = "3.6.0"
 varabyte-kobweb = "0.19.0"
@@ -31,7 +30,6 @@ varabyte-kobweb-core = { module = "com.varabyte.kobweb:kobweb-core ", version.re
 varabyte-kobweb-silk = { module = "com.varabyte.kobweb:kobweb-silk", version.ref = "varabyte-kobweb" }
 google-android-material = { group = "com.google.android.material", name = "material", version.ref = "google-android-material" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
-teogor-crosslens-core = { group = "dev.teogor.crosslens", name = "crosslens-core", version.ref = "teogor-crosslens" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/paletteon-core/build.gradle.kts
+++ b/paletteon-core/build.gradle.kts
@@ -102,7 +102,6 @@ kotlin {
 
                 api(projects.materialColorUtilities)
 
-                implementation(libs.teogor.crosslens.core)
                 implementation(libs.ajalt.colormath)
             }
         }


### PR DESCRIPTION
This PR reverts the `minSdk` version from 24 back to 21 in the Android module to improve device compatibility.  

Investigation revealed that `minSdk 24` was introduced due to a transient dependency on `teogor-crosslens-core`, which was only used in the demo app and not in the core library.  

Changes:
- Updated `minSdk` to 21 in `build.gradle.kts` (Android module)
- Removed `teogor-crosslens-core` from core dependencies
- Ensured all core functionality remains intact without cross-module references

This change ensures broader device support while maintaining full functionality. The demo app can retain higher SDK requirements if needed.