### PR TITLE
Refactor Dokka plugin application and fix rememberSaveable usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,14 +183,13 @@ subprojects {
     }
 }
 
-val excludedProjects = listOf<DelegatingProjectDependency>(
+val excludedProjectsPaths = listOf(
     projects.paletteon,
     projects.demo,
-)
+).map { it.path }
 
 subprojects {
-    // val paths = excludedProjects.map { it.path }
-    // if (!paths.contains(this.path)) {
-    //     apply<DokkaPlugin>()
-    // }
+    if (!excludedProjectsPaths.contains(this.path)) {
+        apply<DokkaPlugin>()
+    }
 }

--- a/demo/composeApp/src/commonMain/kotlin/dev/teogor/paletteon/ShowcaseScreen.kt
+++ b/demo/composeApp/src/commonMain/kotlin/dev/teogor/paletteon/ShowcaseScreen.kt
@@ -223,7 +223,6 @@ private fun ShowcaseScreenContent(
       .fillMaxSize(),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
-
     LazyVerticalGrid(
       state = scrollState,
       columns = if (getContainerWidthInDp() < 800.dp) {
@@ -234,8 +233,7 @@ private fun ShowcaseScreenContent(
       contentPadding = PaddingValues(16.dp),
       verticalArrangement = Arrangement.spacedBy(16.dp),
       horizontalArrangement = Arrangement.spacedBy(16.dp),
-      modifier = Modifier
-        .fillMaxWidth()
+      modifier = Modifier.fillMaxWidth()
     ) {
       colorPalettePreview(
         currentSeedColor = paletteonThemeState.seedColor,
@@ -387,7 +385,7 @@ private fun LazyGridScope.colorPalettePreview(
     val theme = PaletteonTheme.current
     val colors = CorePalette()
 
-    val device = rememberSaveable {
+    val device = remember {
       listOf(
         DeviceType.TV(),
         DeviceType.Mobile(),


### PR DESCRIPTION
This PR includes two main changes:  
1. Refactors the Gradle configuration for the Dokka plugin to exclude the `paletteon` and `demo` projects by switching to an explicit exclusion list with paths.  
2. Fixes improper usage of `rememberSaveable` in demo by removing it and using `remember` to store the `device` value.

These changes improve build configuration clarity and resolve a potential state handling bug in the codebase.
